### PR TITLE
Add ConfigSourceCacheWrapper  to support config cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <commons.logging.version>1.1.1</commons.logging.version>
         <spring.boot.version>1.5.16.RELEASE</spring.boot.version>
         <junit.version>4.13.1</junit.version>
+        <guava.version>31.0.1-jre</guava.version>
     </properties>
 
     <dependencyManagement>
@@ -43,6 +44,11 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <commons.logging.version>1.1.1</commons.logging.version>
         <spring.boot.version>1.5.16.RELEASE</spring.boot.version>
         <junit.version>4.13.1</junit.version>
-        <guava.version>31.0.1-jre</guava.version>
+        <guava.version>27.0-jre</guava.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/com/alipay/sofa/common/config/ConfigManager.java
+++ b/src/main/java/com/alipay/sofa/common/config/ConfigManager.java
@@ -26,6 +26,10 @@ public interface ConfigManager {
 
     <T> T getOrCustomDefault(ConfigKey<T> key, T customDefault);
 
+    <T> T getOrDefaultWithCache(ConfigKey<T> key);
+
+    <T> T getOrCustomDefaultWithCache(ConfigKey<T> key, T customDefault);
+
     void addConfigSource(ConfigSource configSource);
 
     void addConfigListener(ManagementListener configListener);

--- a/src/main/java/com/alipay/sofa/common/config/DefaultConfigManager.java
+++ b/src/main/java/com/alipay/sofa/common/config/DefaultConfigManager.java
@@ -32,16 +32,16 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author zhaowang
  * @version : SofaCommonConfig.java, v 0.1 2020年10月20日 8:30 下午 zhaowang Exp $
  */
-public class DefaultConfigManger implements ConfigManager {
+public class DefaultConfigManager implements ConfigManager {
 
-    public static final Logger LOGGER = LoggerFactory.getLogger(DefaultConfigManger.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(DefaultConfigManager.class);
 
     private final Object EMPTY = new Object();
     private final List<ConfigSource> configSources = new CopyOnWriteArrayList<>();
     private final List<ManagementListener> configListeners = new CopyOnWriteArrayList<>();
     private LoadingCache<ConfigKey, Object> cache;
 
-    public DefaultConfigManger(long expireAfterSecond, long maximumSize) {
+    public DefaultConfigManager(long expireAfterSecond, long maximumSize) {
         this.cache = CacheBuilder.newBuilder()
                 .expireAfterWrite(Duration.ofSeconds(expireAfterSecond))
                 .maximumSize(maximumSize)

--- a/src/main/java/com/alipay/sofa/common/config/DefaultConfigManager.java
+++ b/src/main/java/com/alipay/sofa/common/config/DefaultConfigManager.java
@@ -20,9 +20,8 @@ import com.alipay.sofa.common.utils.OrderComparator;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ExecutionError;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.List;
@@ -33,8 +32,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @version : SofaCommonConfig.java, v 0.1 2020年10月20日 8:30 下午 zhaowang Exp $
  */
 public class DefaultConfigManager implements ConfigManager {
-
-    public static final Logger LOGGER = LoggerFactory.getLogger(DefaultConfigManager.class);
 
     private final Object EMPTY = new Object();
     private final List<ConfigSource> configSources = new CopyOnWriteArrayList<>();
@@ -82,10 +79,14 @@ public class DefaultConfigManager implements ConfigManager {
         Object result = null;
         try {
             result = cache.getUnchecked(key);
+        }catch (ExecutionError error){
+            throw new IllegalStateException(error);
         } catch (UncheckedExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
+            }else{
+                throw new IllegalStateException("Unexpected type of exception when getConfigWithCache:"+cause,cause);
             }
         }
         if (result == EMPTY) {

--- a/src/main/java/com/alipay/sofa/common/config/DefaultConfigManger.java
+++ b/src/main/java/com/alipay/sofa/common/config/DefaultConfigManger.java
@@ -17,9 +17,13 @@
 package com.alipay.sofa.common.config;
 
 import com.alipay.sofa.common.utils.OrderComparator;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -27,21 +31,59 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author zhaowang
  * @version : SofaCommonConfig.java, v 0.1 2020年10月20日 8:30 下午 zhaowang Exp $
  */
-public class DefaultConfigManger implements ConfigManager{
+public class DefaultConfigManger implements ConfigManager {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(DefaultConfigManger.class);
 
+    private final Object EMPTY = new Object();
     private final List<ConfigSource> configSources = new CopyOnWriteArrayList<>();
     private final List<ManagementListener> configListeners = new CopyOnWriteArrayList<>();
+    private LoadingCache<ConfigKey, Object> cache;
+
+    public DefaultConfigManger(long expireAfterSecond, long maximumSize) {
+        this.cache = CacheBuilder.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(expireAfterSecond))
+                .maximumSize(maximumSize)
+                .build(new CacheLoader<ConfigKey,Object >() {
+                    @Override
+                    public Object load(ConfigKey key) {
+                        Object config = getConfig(key, null);
+                        if (config == null) {
+                            return EMPTY;
+                        }
+                        return config;
+                    }
+                });
+    }
+
 
     @Override
     public <T> T getOrDefault(ConfigKey<T> key) {
-        return getConfig(key,key.getDefaultValue());
+        return getConfig(key, key.getDefaultValue());
     }
 
     @Override
     public <T> T getOrCustomDefault(ConfigKey<T> key, T customDefault) {
-        return getConfig(key,customDefault);
+        return getConfig(key, customDefault);
+    }
+
+    @Override
+    public <T> T getOrDefaultWithCache(ConfigKey<T> key) {
+        return getConfigWithCache(key, key.getDefaultValue());
+    }
+
+    @Override
+    public <T> T getOrCustomDefaultWithCache(ConfigKey<T> key, T customDefault) {
+        return getConfigWithCache(key, customDefault);
+    }
+
+    private <T> T getConfigWithCache(ConfigKey<T> key, T defaultValue) {
+        Object result = cache.getUnchecked(key);
+        if(result == EMPTY){
+            return defaultValue;
+        }else{
+            return (T) result;
+        }
     }
 
     public <T> T getConfig(ConfigKey<T> key, T defaultValue) {
@@ -62,20 +104,20 @@ public class DefaultConfigManger implements ConfigManager{
 
     private <T> void onLoadDefaultValue(ConfigKey<T> key, Object defaultValue) {
         for (ManagementListener configListener : configListeners) {
-            configListener.onLoadDefaultValue(key,defaultValue);
+            configListener.onLoadDefaultValue(key, defaultValue);
         }
     }
 
 
     private <T> void beforeConfigLoading(ConfigKey<T> key) {
         for (ManagementListener configListener : configListeners) {
-            configListener.beforeConfigLoading(key,configSources);
+            configListener.beforeConfigLoading(key, configSources);
         }
     }
 
     private <T> void onConfigLoaded(ConfigKey<T> key, ConfigSource configSource) {
         for (ManagementListener configListener : configListeners) {
-            configListener.afterConfigLoaded(key,configSource,configSources);
+            configListener.afterConfigLoaded(key, configSource, configSources);
         }
     }
 

--- a/src/main/java/com/alipay/sofa/common/config/SofaConfigs.java
+++ b/src/main/java/com/alipay/sofa/common/config/SofaConfigs.java
@@ -20,6 +20,9 @@ import com.alipay.sofa.common.config.listener.LogConfigListener;
 import com.alipay.sofa.common.config.source.SystemEnvConfigSource;
 import com.alipay.sofa.common.config.source.SystemPropertyConfigSource;
 
+import static com.alipay.sofa.common.log.Constants.SOFA_MIDDLEWARE_CONFIG_CACHE_EXPIRE_TIME;
+import static com.alipay.sofa.common.log.Constants.SOFA_MIDDLEWARE_CONFIG_CACHE_MAX_SIZE;
+
 /**
  * @author zhaowang
  * @version : SofaCommonConfig.java, v 0.1 2020年12月01日 11:54 上午 zhaowang Exp $
@@ -27,9 +30,16 @@ import com.alipay.sofa.common.config.source.SystemPropertyConfigSource;
 public class SofaConfigs {
 
     private static final DefaultConfigManger INSTANCE;
+    public static final String               DEFAULT_EXPIRE_AFTER_SECOND = "5";
+    public static final String               DEFAULT_MAX_SIZE            = "1000";
 
     static {
-        INSTANCE = new DefaultConfigManger();
+        long expireAfterSecond = Long.parseLong(System.getProperty(
+            SOFA_MIDDLEWARE_CONFIG_CACHE_EXPIRE_TIME, DEFAULT_EXPIRE_AFTER_SECOND));
+        long maxSize = Long.parseLong(System.getProperty(SOFA_MIDDLEWARE_CONFIG_CACHE_MAX_SIZE,
+            DEFAULT_MAX_SIZE));
+
+        INSTANCE = new DefaultConfigManger(expireAfterSecond, maxSize);
         // add ConfigSource
         INSTANCE.addConfigSource(new SystemPropertyConfigSource());
         INSTANCE.addConfigSource(new SystemEnvConfigSource());
@@ -44,6 +54,14 @@ public class SofaConfigs {
 
     public static <T> T getOrCustomDefault(ConfigKey<T> key, T customDefault) {
         return INSTANCE.getOrCustomDefault(key, customDefault);
+    }
+
+    public static <T> T getOrCustomDefaultWithCache(ConfigKey<T> key, T customDefault) {
+        return INSTANCE.getOrCustomDefaultWithCache(key, customDefault);
+    }
+
+    public static <T> T getOrDefaultWithCache(ConfigKey<T> key) {
+        return INSTANCE.getOrDefaultWithCache(key);
     }
 
     public static void addConfigSource(ConfigSource configSource) {

--- a/src/main/java/com/alipay/sofa/common/config/SofaConfigs.java
+++ b/src/main/java/com/alipay/sofa/common/config/SofaConfigs.java
@@ -29,7 +29,7 @@ import static com.alipay.sofa.common.log.Constants.SOFA_MIDDLEWARE_CONFIG_CACHE_
  */
 public class SofaConfigs {
 
-    private static final DefaultConfigManger INSTANCE;
+    private static final DefaultConfigManager INSTANCE;
     public static final String               DEFAULT_EXPIRE_AFTER_SECOND = "5";
     public static final String               DEFAULT_MAX_SIZE            = "1000";
 
@@ -39,7 +39,7 @@ public class SofaConfigs {
         long maxSize = Long.parseLong(System.getProperty(SOFA_MIDDLEWARE_CONFIG_CACHE_MAX_SIZE,
             DEFAULT_MAX_SIZE));
 
-        INSTANCE = new DefaultConfigManger(expireAfterSecond, maxSize);
+        INSTANCE = new DefaultConfigManager(expireAfterSecond, maxSize);
         // add ConfigSource
         INSTANCE.addConfigSource(new SystemPropertyConfigSource());
         INSTANCE.addConfigSource(new SystemEnvConfigSource());
@@ -72,7 +72,7 @@ public class SofaConfigs {
         INSTANCE.addConfigListener(configListener);
     }
 
-    public static DefaultConfigManger getInstance() {
+    public static DefaultConfigManager getInstance() {
         return INSTANCE;
     }
 }

--- a/src/main/java/com/alipay/sofa/common/config/SofaConfigs.java
+++ b/src/main/java/com/alipay/sofa/common/config/SofaConfigs.java
@@ -30,8 +30,8 @@ import static com.alipay.sofa.common.log.Constants.SOFA_MIDDLEWARE_CONFIG_CACHE_
 public class SofaConfigs {
 
     private static final DefaultConfigManager INSTANCE;
-    public static final String               DEFAULT_EXPIRE_AFTER_SECOND = "5";
-    public static final String               DEFAULT_MAX_SIZE            = "1000";
+    public static final String                DEFAULT_EXPIRE_AFTER_SECOND = "5";
+    public static final String                DEFAULT_MAX_SIZE            = "1000";
 
     static {
         long expireAfterSecond = Long.parseLong(System.getProperty(

--- a/src/main/java/com/alipay/sofa/common/config/source/ConfigSourceCacheWrapper.java
+++ b/src/main/java/com/alipay/sofa/common/config/source/ConfigSourceCacheWrapper.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.config.source;
+
+import com.alipay.sofa.common.utils.StringUtil;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author zhaowang
+ * @version : CacheConfigSourceWrapper.java, v 0.1 2021年12月20日 8:19 下午 zhaowang
+ */
+public class ConfigSourceCacheWrapper extends AbstractConfigSource {
+
+    private AbstractConfigSource         delegate;
+    private LoadingCache<String, String> cache;
+
+    public ConfigSourceCacheWrapper(AbstractConfigSource delegate, long expireAfterSecond) {
+        this.delegate = delegate;
+        this.cache = CacheBuilder.newBuilder()
+            .expireAfterWrite(Duration.ofSeconds(expireAfterSecond))
+            .build(new CacheLoader<String, String>() {
+                @Override
+                public String load(String key) {
+                    return delegate.doGetConfig(key);
+                }
+            });
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public String doGetConfig(String key) {
+        if (key == null) {
+            return null;
+        }
+        try {
+            return cache.get(key);
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause != null) {
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                } else {
+                    throw new RuntimeException(cause);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean hasKey(String key) {
+        return StringUtil.isNotBlank(doGetConfig(key));
+    }
+
+    @Override
+    public int getOrder() {
+        return delegate.getOrder();
+    }
+}

--- a/src/main/java/com/alipay/sofa/common/config/source/ConfigSourceCacheWrapper.java
+++ b/src/main/java/com/alipay/sofa/common/config/source/ConfigSourceCacheWrapper.java
@@ -41,7 +41,12 @@ public class ConfigSourceCacheWrapper extends AbstractConfigSource {
             .build(new CacheLoader<String, String>() {
                 @Override
                 public String load(String key) {
-                    return delegate.doGetConfig(key);
+                    String value = delegate.doGetConfig(key);
+                    if (value == null) {
+                        return "";
+                    } else {
+                        return value;
+                    }
                 }
             });
     }

--- a/src/main/java/com/alipay/sofa/common/log/Constants.java
+++ b/src/main/java/com/alipay/sofa/common/log/Constants.java
@@ -135,4 +135,8 @@ public interface Constants {
     String  LOGGING_CONFIG_PATH                                   = "logging.config.%s";
     // config marker
     String  SOFA_LOG_FIRST_INITIALIZE                             = "sofa.log.first.initialize";
+    // SofaConfigs cache expire time
+    String  SOFA_MIDDLEWARE_CONFIG_CACHE_EXPIRE_TIME              = "sofa.middleware.config.cache.expireTime";
+    // SofaConfigs cache max size
+    String  SOFA_MIDDLEWARE_CONFIG_CACHE_MAX_SIZE                 = "sofa.middleware.config.cache.maxSize";
 }

--- a/src/test/java/com/alipay/sofa/common/config/CommonConfigTest.java
+++ b/src/test/java/com/alipay/sofa/common/config/CommonConfigTest.java
@@ -94,7 +94,7 @@ public class CommonConfigTest {
 
     @Test
     public void testConfigSourceOrder() {
-        DefaultConfigManger config = SofaConfigs.getInstance();
+        DefaultConfigManager config = SofaConfigs.getInstance();
 
         SofaConfigs.addConfigSource(new OrderConfigSource(1));
         SofaConfigs.addConfigSource(new OrderConfigSource(2));
@@ -117,7 +117,7 @@ public class CommonConfigTest {
 
     @Test
     public void testListenerSourceOrder() {
-        DefaultConfigManger config = SofaConfigs.getInstance();
+        DefaultConfigManager config = SofaConfigs.getInstance();
 
         SofaConfigs.addConfigListener(new OrderConfigListener(1));
         SofaConfigs.addConfigListener(new OrderConfigListener(2));
@@ -140,7 +140,7 @@ public class CommonConfigTest {
 
     @Test
     public void testLogListenerOrder() {
-        DefaultConfigManger config = new DefaultConfigManger(1, 100);
+        DefaultConfigManager config = new DefaultConfigManager(1, 100);
 
         config.addConfigListener(new OrderConfigListener(1));
         config.addConfigListener(new OrderConfigListener(2));
@@ -172,7 +172,7 @@ public class CommonConfigTest {
         // test custom
         Assert.assertEquals(custom, SofaConfigs.getOrCustomDefaultWithCache(configKey, custom));
 
-        DefaultConfigManger configManger = new DefaultConfigManger(1, 1000);
+        DefaultConfigManager configManger = new DefaultConfigManager(1, 1000);
         configManger.addConfigSource(configSource);
 
         Assert.assertEquals(DEFAULT, configManger.getOrDefaultWithCache(configKey));
@@ -190,7 +190,7 @@ public class CommonConfigTest {
         String DEFAULT = "default";
         String custom = "custom";
         // test exception
-        DefaultConfigManger configManger = new DefaultConfigManger(1, 1000);
+        DefaultConfigManager configManger = new DefaultConfigManager(1, 1000);
         ExceptionConfigSource exceptionConfigSource = new ExceptionConfigSource(Ordered.HIGHEST_PRECEDENCE);
         configManger.addConfigSource(exceptionConfigSource);
         ConfigKey<String> configKey = ConfigKey.build("key1", DEFAULT, true, COMMON_LOG_FILE.getDescription());

--- a/src/test/java/com/alipay/sofa/common/config/ConfigSourceCacheWrapperTest.java
+++ b/src/test/java/com/alipay/sofa/common/config/ConfigSourceCacheWrapperTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.config;
+
+import com.alipay.sofa.common.config.source.AbstractConfigSource;
+import com.alipay.sofa.common.config.source.ConfigSourceCacheWrapper;
+import com.alipay.sofa.common.config.source.ConfigSourceOrder;
+import com.alipay.sofa.common.config.source.SystemPropertyConfigSource;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author zhaowang
+ * @version : ConfigSourceCacheWrapperTest.java, v 0.1 2021年12月20日 8:19 下午 zhaowang
+ */
+public class ConfigSourceCacheWrapperTest {
+
+    private ConfigSourceCacheWrapper cacheWrapper = new ConfigSourceCacheWrapper(
+            new SystemPropertyConfigSource(), 1);
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("key1", "value1");
+        System.setProperty("key2", "");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("key1");
+        System.clearProperty("key2");
+    }
+
+    @Test
+    public void testNull() {
+        Assert.assertEquals(null, cacheWrapper.doGetConfig(null));
+        Assert.assertEquals(false, cacheWrapper.hasKey(null));
+    }
+
+    @Test
+    public void testCommon() {
+        Assert.assertEquals("value1", cacheWrapper.doGetConfig("key1"));
+        Assert.assertEquals("", cacheWrapper.doGetConfig("key2"));
+        Assert.assertTrue(cacheWrapper.hasKey("key1"));
+        Assert.assertFalse(cacheWrapper.hasKey("key2"));
+    }
+
+    @Test
+    public void testException() {
+        NullPointerException NPE = new NullPointerException();
+        ExceptionConfigSource exceptionConfigSource = new ExceptionConfigSource(NPE);
+        ConfigSourceCacheWrapper cacheWrapper = new ConfigSourceCacheWrapper(exceptionConfigSource,
+                1);
+        try {
+            cacheWrapper.doGetConfig("");
+            Assert.fail();
+        } catch (Throwable t) {
+            Assert.assertTrue(t instanceof NullPointerException);
+            Assert.assertSame(NPE, t);
+        }
+
+        try {
+            cacheWrapper.hasKey("");
+            Assert.fail();
+        } catch (Throwable t) {
+            Assert.assertTrue(t instanceof NullPointerException);
+            Assert.assertSame(NPE, t);
+        }
+
+    }
+
+    @Test
+    public void testGetName() {
+        Assert.assertEquals("SystemProperty", cacheWrapper.getName());
+    }
+
+    @Test
+    public void testOrder() {
+        Assert.assertEquals(ConfigSourceOrder.SYSTEM_PROPERTY, cacheWrapper.getOrder());
+    }
+
+    @Test
+    public void testCacheTime() throws InterruptedException {
+        System.setProperty("key3", "value3");
+        Assert.assertEquals("value3", cacheWrapper.doGetConfig("key3"));
+        System.setProperty("key3", "value4");
+        Thread.sleep(500);
+        Assert.assertEquals("value3", cacheWrapper.doGetConfig("key3"));
+        Thread.sleep(500);
+        Assert.assertEquals("value4", cacheWrapper.doGetConfig("key3"));
+        System.clearProperty("key3");
+    }
+
+    public class ExceptionConfigSource extends AbstractConfigSource {
+        private RuntimeException t;
+
+        public ExceptionConfigSource(RuntimeException t) {
+            this.t = t;
+        }
+
+        @Override
+        public String getName() {
+            return getClass().getName();
+        }
+
+        @Override
+        public String doGetConfig(String key) {
+            throw t;
+        }
+
+        @Override
+        public boolean hasKey(String key) {
+            throw t;
+        }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
+    }
+}

--- a/src/test/java/com/alipay/sofa/common/config/ConfigSourceCacheWrapperTest.java
+++ b/src/test/java/com/alipay/sofa/common/config/ConfigSourceCacheWrapperTest.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class ConfigSourceCacheWrapperTest {
 
     private ConfigSourceCacheWrapper cacheWrapper = new ConfigSourceCacheWrapper(
-            new SystemPropertyConfigSource(), 1);
+                                                      new SystemPropertyConfigSource(), 1);
 
     @BeforeClass
     public static void beforeClass() {
@@ -65,7 +65,7 @@ public class ConfigSourceCacheWrapperTest {
         NullPointerException NPE = new NullPointerException();
         ExceptionConfigSource exceptionConfigSource = new ExceptionConfigSource(NPE);
         ConfigSourceCacheWrapper cacheWrapper = new ConfigSourceCacheWrapper(exceptionConfigSource,
-                1);
+            1);
         try {
             cacheWrapper.doGetConfig("");
             Assert.fail();
@@ -81,7 +81,18 @@ public class ConfigSourceCacheWrapperTest {
             Assert.assertTrue(t instanceof NullPointerException);
             Assert.assertSame(NPE, t);
         }
+    }
 
+    @Test
+    public void testNotExist() throws InterruptedException {
+        String notExistKey = "key3";
+        String value = "value3";
+        System.clearProperty(notExistKey);
+        Assert.assertEquals("", cacheWrapper.doGetConfig(notExistKey));
+        System.setProperty(notExistKey, value);
+        Assert.assertEquals("", cacheWrapper.doGetConfig(notExistKey));
+        Thread.sleep(1000);
+        Assert.assertEquals(value, cacheWrapper.doGetConfig(notExistKey));
     }
 
     @Test


### PR DESCRIPTION
### Motivation:
Getting config may cost a lot. I add a guava cache wrapper class to save the cost. 



