### PR TITLE
upgrade to 1.4.0, add recorder support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.alipay.sofa.common</groupId>
     <artifactId>sofa-common-tools</artifactId>
-    <version>1.3.15</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/alipay/sofa/common/insight/NoopRecorder.java
+++ b/src/main/java/com/alipay/sofa/common/insight/NoopRecorder.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.insight;
+
+/**
+ * @author muqingcai
+ * @date 2024年4月19日 上午9:54:51
+ */
+public class NoopRecorder implements Recorder {
+    public static final NoopRecorder INSTANCE = new NoopRecorder();
+
+    private NoopRecorder() {
+    }
+
+    @Override
+    public void start(RecordScene scene, RecordContext context) {
+
+    }
+
+    @Override
+    public void stop(RecordScene scene, RecordContext context) {
+
+    }
+}

--- a/src/main/java/com/alipay/sofa/common/insight/RecordContext.java
+++ b/src/main/java/com/alipay/sofa/common/insight/RecordContext.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.insight;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author muqingcai
+ * @date 2024年4月19日 上午9:54:59
+ */
+public class RecordContext {
+    private int                 requestId;
+    private String              traceId;
+    private String              rpcId;
+    private String              targetServiceUniqueName;
+    private String              methodName;
+    private String              moduleName;
+    private String              beanName;
+    private Map<String, Object> extraInfo;
+
+    /**
+     * Constructor.
+     */
+    public RecordContext() {
+        this.extraInfo = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param requestId the request id
+     */
+    public RecordContext(int requestId) {
+        this.requestId = requestId;
+        this.extraInfo = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param moduleName the module name
+     * @param beanName   the bean name
+     */
+    public RecordContext(String moduleName, String beanName) {
+        this.extraInfo = new ConcurrentHashMap<>();
+        this.moduleName = moduleName;
+        this.beanName = beanName;
+    }
+
+    /**
+     * Gets get request id.
+     *
+     * @return the get request id
+     */
+    public int getRequestId() {
+        return requestId;
+    }
+
+    /**
+     * Sets set request id.
+     *
+     * @param requestId the request id
+     */
+    public void setRequestId(int requestId) {
+        this.requestId = requestId;
+    }
+
+    /**
+     * Gets get trace id.
+     *
+     * @return the get trace id
+     */
+    public String getTraceId() {
+        return traceId;
+    }
+
+    /**
+     * Sets set trace id.
+     *
+     * @param traceId the trace id
+     */
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    /**
+     * Gets get rpc id.
+     *
+     * @return the get rpc id
+     */
+    public String getRpcId() {
+        return rpcId;
+    }
+
+    /**
+     * Sets set rpc id.
+     *
+     * @param rpcId the rpc id
+     */
+    public void setRpcId(String rpcId) {
+        this.rpcId = rpcId;
+    }
+
+    /**
+     * Gets get target service unique name.
+     *
+     * @return the get target service unique name
+     */
+    public String getTargetServiceUniqueName() {
+        return targetServiceUniqueName;
+    }
+
+    /**
+     * Sets set target service unique name.
+     *
+     * @param targetServiceUniqueName the target service unique name
+     */
+    public void setTargetServiceUniqueName(String targetServiceUniqueName) {
+        this.targetServiceUniqueName = targetServiceUniqueName;
+    }
+
+    /**
+     * Gets get method name.
+     *
+     * @return the get method name
+     */
+    public String getMethodName() {
+        return methodName;
+    }
+
+    /**
+     * Sets set method name.
+     *
+     * @param methodName the method name
+     */
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+
+    /**
+     * Gets get module name.
+     *
+     * @return the get module name
+     */
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    /**
+     * Sets set module name.
+     *
+     * @param moduleName the module name
+     */
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    /**
+     * Gets get bean name.
+     *
+     * @return the get bean name
+     */
+    public String getBeanName() {
+        return beanName;
+    }
+
+    /**
+     * Sets set bean name.
+     *
+     * @param beanName the bean name
+     */
+    public void setBeanName(String beanName) {
+        this.beanName = beanName;
+    }
+
+    /**
+     * Gets get extra info.
+     *
+     * @return the get extra info
+     */
+    public Map<String, Object> getExtraInfo() {
+        return extraInfo;
+    }
+
+    /**
+     * Sets set extra info.
+     *
+     * @param extraInfo the extra info
+     */
+    public void setExtraInfo(Map<String, Object> extraInfo) {
+        this.extraInfo = extraInfo;
+    }
+
+    /**
+     * To string string.
+     *
+     * @return the string
+     */
+    @Override
+    public String toString() {
+        return "RecordContext{" + "requestId=" + requestId + ", traceId='" + traceId + '\''
+               + ", rpcId='" + rpcId + '\'' + ", targetServiceUniqueName='"
+               + targetServiceUniqueName + '\'' + ", methodName='" + methodName + '\''
+               + ", moduleName='" + moduleName + '\'' + ", beanName='" + beanName + '\''
+               + ", extraInfo=" + extraInfo + '}';
+    }
+}

--- a/src/main/java/com/alipay/sofa/common/insight/RecordScene.java
+++ b/src/main/java/com/alipay/sofa/common/insight/RecordScene.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.insight;
+
+/**
+ * @author muqingcai
+ * @date 2024年4月19日 上午9:55:54
+ */
+public enum RecordScene {
+    /**
+     * record 场景
+     */
+    BOLT_REQUEST_HANDLE("boltRequestHandle", "bolt 协议 RPC 请求处理"),
+
+    TR_REQUEST_HANDLE("trRequestHandle", "tr 协议 RPC 请求处理"),
+
+    SOFA_STARTUP("sofaStartup", "应用启动"),
+
+    SPRING_BEAN_REFRESH("springBeanRefresh", "应用 bean 刷新");
+
+    private final String scene;
+    private final String desc;
+
+    RecordScene(String scene, String desc) {
+        this.scene = scene;
+        this.desc = desc;
+    }
+
+    /**
+     * Gets get scene.
+     *
+     * @return the get scene
+     */
+    public String getScene() {
+        return scene;
+    }
+
+    /**
+     * Gets get desc.
+     *
+     * @return the get desc
+     */
+    public String getDesc() {
+        return desc;
+    }
+}

--- a/src/main/java/com/alipay/sofa/common/insight/Recorder.java
+++ b/src/main/java/com/alipay/sofa/common/insight/Recorder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.insight;
+
+/**
+ * @author muqingcai
+ * @date 2024年4月11日 下午9:56:03
+ */
+public interface Recorder {
+
+    /**
+     * Start record
+     *
+     * @param scene   the scene
+     * @param context the context
+     */
+    void start(RecordScene scene, RecordContext context);
+
+    /**
+     * Stop record
+     *
+     * @param scene   the scene
+     * @param context the context
+     */
+    void stop(RecordScene scene, RecordContext context);
+}

--- a/src/main/java/com/alipay/sofa/common/insight/RecorderManager.java
+++ b/src/main/java/com/alipay/sofa/common/insight/RecorderManager.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.insight;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * @author muqingcai
+ * @date 2024年4月11日 下午2:32:31
+ */
+public class RecorderManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecorderManager.class);
+    private static final AtomicReference<Recorder> RECORDER = new AtomicReference<>(NoopRecorder.INSTANCE);
+
+    public static Recorder getRecorder() {
+        return RECORDER.get();
+    }
+
+    public static void init() {
+        Recorder targetRecorder = null;
+        ServiceLoader<Recorder> loader = ServiceLoader.load(Recorder.class);
+        Iterator<Recorder> iterator = loader.iterator();
+        if (iterator.hasNext()) {
+            targetRecorder = iterator.next();
+        }
+        if (targetRecorder != null) {
+            boolean state = RECORDER.compareAndSet(NoopRecorder.INSTANCE, targetRecorder);
+            if (state) {
+                if (LOGGER.isInfoEnabled()) {
+                    LOGGER.info("Init recorder successfully, class: {}", targetRecorder.getClass().getName());
+                }
+            } else {
+                LOGGER.warn("Cannot init recorder repeatedly ");
+            }
+        }
+    }
+}

--- a/src/main/java/com/alipay/sofa/common/insight/RecorderManager.java
+++ b/src/main/java/com/alipay/sofa/common/insight/RecorderManager.java
@@ -16,8 +16,8 @@
  */
 package com.alipay.sofa.common.insight;
 
+import com.alipay.sofa.common.config.log.ConfigLoggerFactory;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @date 2024年4月11日 下午2:32:31
  */
 public class RecorderManager {
-    private static final Logger LOGGER = LoggerFactory.getLogger(RecorderManager.class);
+    private static final Logger LOGGER = ConfigLoggerFactory.getLogger(RecorderManager.class);
     private static final AtomicReference<Recorder> RECORDER = new AtomicReference<>(NoopRecorder.INSTANCE);
 
     public static Recorder getRecorder() {

--- a/src/test/java/com/alipay/sofa/common/recorder/RecorderManagerTest.java
+++ b/src/test/java/com/alipay/sofa/common/recorder/RecorderManagerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.recorder;
+
+import com.alipay.sofa.common.insight.NoopRecorder;
+import com.alipay.sofa.common.insight.Recorder;
+import com.alipay.sofa.common.insight.RecorderManager;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author muqingcai
+ * @date 2024年5月13日 下午12:45:52
+ */
+public class RecorderManagerTest {
+    @Test
+    public void testGetRecorder() {
+        Recorder recorderBeforeInit = RecorderManager.getRecorder();
+        Assert.assertTrue(recorderBeforeInit instanceof NoopRecorder);
+
+        RecorderManager.init();
+        Recorder recorderAfterInit = RecorderManager.getRecorder();
+        Assert.assertTrue(recorderAfterInit instanceof SampleRecorder);
+    }
+}

--- a/src/test/java/com/alipay/sofa/common/recorder/SampleRecorder.java
+++ b/src/test/java/com/alipay/sofa/common/recorder/SampleRecorder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.common.recorder;
+
+import com.alipay.sofa.common.insight.RecordContext;
+import com.alipay.sofa.common.insight.RecordScene;
+import com.alipay.sofa.common.insight.Recorder;
+
+import java.io.PrintStream;
+
+/**
+ * @author muqingcai
+ * @date 2024年5月13日 下午12:45:58
+ */
+public class SampleRecorder implements Recorder {
+    private static final PrintStream TTY = System.out;
+
+    @Override
+    public void start(RecordScene scene, RecordContext context) {
+        TTY.println("Recorder start, scene: " + scene + " context: " + context);
+    }
+
+    @Override
+    public void stop(RecordScene scene, RecordContext context) {
+        TTY.println("Recorder stop, scene: " + scene + " context: " + context);
+    }
+}

--- a/src/test/resources/META-INF/services/com.alipay.sofa.common.insight.Recorder
+++ b/src/test/resources/META-INF/services/com.alipay.sofa.common.insight.Recorder
@@ -1,0 +1,1 @@
+com.alipay.sofa.common.recorder.SampleRecorder


### PR DESCRIPTION
### Motivation:

In SOFA application scenario, RPC time-consuming analysis and application startup time-consuming analysis have profiling demands, in order to separate the recorder interface and implementation, need to provide an service discovery mechanism.

### Modification:

add recorder spi and provide recorderManger to discover implementation

